### PR TITLE
make compatible with beta api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Brigade SDK for JavaScript
 
-This is an _experimental_ JavaScript (and TypeScript) SDK for the WIP Brigade 2
-event-driven scripting platform (i.e. Brigade v2 itself remains a WIP.)
+This is a JavaScript (and TypeScript) SDK compatible with the _beta_ series of
+releases of the Brigade 2 event-driven scripting platform.
 
 ## Supported Runtimes
 

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -1,4 +1,4 @@
 export * from "./lists"
 export * from "./objects"
 
-export const APIVersion = "brigade.sh/v2-alpha.5"
+export const APIVersion = "brigade.sh/v2-beta"


### PR DESCRIPTION
This is in preparation for Brigade 2's own first beta release.

Brigade 2's worker has a dependency on this SDK, so we should release a beta-compatible SDK _prior_ to releasing a Brigade 2 beta, or else the workers won't be able to talk back to the API server.