### PR TITLE
brigade.ts: fix releaseTagRegex

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,6 +1,6 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup } from "@brigadecore/brigadier"
 
-const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
+const releaseTagRegex = /^refs\/tags\/v([0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
 const img = "node:12.3.1-stretch"
 const localPath = "/workspaces/brigade-sdk-for-js"


### PR DESCRIPTION
This PR fixes the `brigade.ts` script to not incorporate the leading `v` from a semver tag into the version number used when publishing to NPM.

The old `brigade.js` script for Brigade 1.x used to account for this, but this mistake was re-introduced somehow when we started dogfooding Brigade 2.