### PR TITLE
remove ability to mount host docker socket to job containers

### DIFF
--- a/src/core/jobs.ts
+++ b/src/core/jobs.ts
@@ -148,8 +148,18 @@ export interface JobContainerSpec extends ContainerSpec {
    * DISCOURAGED. Note this field REQUESTS to mount the host's Docker socket
    * into the container, but that may be disallowed by Project-level
    * configuration.
+   * 
+   * Host Docker socket access may be disallowed by Brigade project configuration.
+   * If so, the container will run without such access.
+   * 
+   * Note: This is being removed for the 2.0.0 release because of security
+   * issues AND declining usefulness. (Many Kubernetes distros now use
+   * containerd instead of Docker.) This can be put back in the future if the
+   * need is proven AND if it can be done safely.
+   * 
+   * For more details, see https://github.com/brigadecore/brigade/issues/1666
    */
-	useHostDockerSocket?: boolean
+	// useHostDockerSocket?: boolean
 }
 
 /**

--- a/src/core/workers.ts
+++ b/src/core/workers.ts
@@ -243,8 +243,18 @@ export interface JobPolicies {
   /**
    * Specifies whether the Worker is permitted to launch Jobs that mount the
    * underlying host's Docker socket into its own file system
+   * 
+   * Host Docker socket access may be disallowed by Brigade project configuration.
+   * If so, the container will run without such access.
+   * 
+   * Note: This is being removed for the 2.0.0 release because of security
+   * issues AND declining usefulness. (Many Kubernetes distros now use
+   * containerd instead of Docker.) This can be put back in the future if the
+   * need is proven AND if it can be done safely.
+   * 
+   * For more details, see https://github.com/brigadecore/brigade/issues/1666
    */
-  allowDockerSocketMount?: boolean
+  // allowDockerSocketMount?: boolean
 }
 
 /**


### PR DESCRIPTION
This corresponds to recent changes in the API.

See https://github.com/brigadecore/brigade/issues/1666 and https://github.com/brigadecore/brigade/pull/1701