### PR TITLE
switch to the stable api

### DIFF
--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -1,4 +1,4 @@
 export * from "./lists"
 export * from "./objects"
 
-export const APIVersion = "brigade.sh/v2-beta"
+export const APIVersion = "brigade.sh/v2"


### PR DESCRIPTION
Will cut v2.0.0-rc.1 after this is merged.

This is a dependency for the main repo's RC.