### PR TITLE
remove mention for beta compatibility from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ![build](https://badgr.brigade2.io/v1/github/checks/brigadecore/brigade-sdk-for-js/badge.svg?appID=99005)
 [![slack](https://img.shields.io/badge/slack-brigade-brightgreen.svg?logo=slack)](https://kubernetes.slack.com/messages/C87MF1RFD)
 
-This is a JavaScript (and TypeScript) SDK compatible with the _beta_ series of
-releases of the Brigade 2 event-driven scripting platform.
+This is a Brigade 2-compatible SDK for JavaScript and TypeScript.
 
 ## Supported Runtimes
 


### PR DESCRIPTION
The head of the main branch now supports the stable API, so we should remove mention that this SDK is compatible with the beta series of Brigade 2 releases. 