### PR TITLE
fix incorrect job status field name

### DIFF
--- a/src/core/jobs.ts
+++ b/src/core/jobs.ts
@@ -71,7 +71,7 @@ export interface Job {
   /**
    * Contains details of the Job's current state
    */
-  Status?: JobStatus
+  status?: JobStatus
 }
 
 /**


### PR DESCRIPTION
This case error is causing some problems. The field in the JSON we consume from the API is `status`, so the field name should also be `status`, not `Status`.