### PR TITLE
add support for the new whoami endpoint

### DIFF
--- a/src/authn/api_client.ts
+++ b/src/authn/api_client.ts
@@ -38,8 +38,8 @@ export class APIClient {
    * Returns a PrincipalReference for the currently authenticated principal.
    *
    * @returns A PrincipalReference for the currently authenticated principal
-   */
-   public async whoAmI(): Promise<PrincipalReference> {
+  */
+  public async whoAmI(): Promise<PrincipalReference> {
     const req = new rm.Request("GET", "v2/whoami")
     return this.rmClient.executeRequest(req) as Promise<PrincipalReference>
   }

--- a/src/authn/api_client.ts
+++ b/src/authn/api_client.ts
@@ -1,5 +1,7 @@
+
 import * as rm from "../rest_machinery"
 
+import { PrincipalReference } from "../lib/authz"
 import { ServiceAccountsClient } from "./service_accounts"
 import { SessionsClient } from "./sessions"
 import { UsersClient } from "./users"
@@ -9,6 +11,7 @@ import { UsersClient } from "./users"
  * authn module.
  */
 export class APIClient {
+  private rmClient: rm.Client
   private serviceAccountsClient: ServiceAccountsClient
   private sessionsClient: SessionsClient
   private usersClient: UsersClient
@@ -25,9 +28,20 @@ export class APIClient {
    * new APIClient("https://brigade.example.com", apiToken, {allowInsecureConnections: true})
    */
   constructor(apiAddress: string, apiToken: string, opts?: rm.APIClientOptions) {
+    this.rmClient = new rm.Client(apiAddress, apiToken, opts)
     this.serviceAccountsClient = new ServiceAccountsClient(apiAddress, apiToken, opts)
     this.sessionsClient = new SessionsClient(apiAddress, apiToken, opts)
     this.usersClient = new UsersClient(apiAddress, apiToken, opts)
+  }
+
+  /**
+   * Returns a PrincipalReference for the currently authenticated principal.
+   *
+   * @returns A PrincipalReference for the currently authenticated principal
+   */
+   public async whoAmI(): Promise<PrincipalReference> {
+    const req = new rm.Request("GET", "v2/whoami")
+    return this.rmClient.executeRequest(req) as Promise<PrincipalReference>
   }
 
   /**

--- a/test/authn/api_client.ts
+++ b/test/authn/api_client.ts
@@ -1,15 +1,34 @@
 import { APIClient } from "../../src/authn/api_client"
+import { PrincipalTypeUser } from "../../src/authz/role_assignments"
 
 import * as common from "../common"
 
 import "mocha"
 import { assert } from "chai"
+import { PrincipalReference } from "../../src/lib/authz"
 
 describe("api_client", () => {
 
   describe("APIClient", () => {
 
     const client = new APIClient(common.testAPIAddress, common.testAPIToken)
+
+    describe("#whoami", () => {
+      it("should send/receive properly over HTTP", async () => { 
+        const testRef: PrincipalReference = {
+          type: PrincipalTypeUser,
+          id: "stark"
+        }
+        await common.testClient({
+          expectedRequestMethod: "GET",
+          expectedRequestPath: "/v2/whoami",
+          mockResponseBody: testRef,
+          clientInvocationLogic: () => {
+            return client.whoAmI()
+          }
+        })
+      })
+    })
 
     describe("#serviceAccounts", () => {
       it("should return a service accounts client", () => {


### PR DESCRIPTION
Adds support for the new `v2/whoami` endpoint that was added to the API server in https://github.com/brigadecore/brigade/pull/1796.

This is needed to continue work on https://github.com/krancour/kashti-tng