### PR TITLE
add fallible field to JobSpec

### DIFF
--- a/src/core/jobs.ts
+++ b/src/core/jobs.ts
@@ -109,11 +109,11 @@ export interface JobSpec {
    */
   host?: JobHost
   /** Specifies whether the job is permitted to fail WITHOUT causing the
-    * worker process to fail. The API server does not use this field directly,
-    * but it is information that may be valuable to gateways that report job
-    * success/failure upstream to original event sources.
-    */
-  fallible?: Boolean
+   * worker process to fail. The API server does not use this field directly,
+   * but it is information that may be valuable to gateways that report job
+   * success/failure upstream to original event sources.
+   */
+  fallible?: boolean
 }
 
 /**

--- a/src/core/jobs.ts
+++ b/src/core/jobs.ts
@@ -108,6 +108,12 @@ export interface JobSpec {
    * operating system (i.e. Windows) or specific hardware (e.g. a GPU.)
    */
   host?: JobHost
+  /** Specifies whether the job is permitted to fail WITHOUT causing the
+    * worker process to fail. The API server does not use this field directly,
+    * but it is information that may be valuable to gateways that report job
+    * success/failure upstream to original event sources.
+    */
+  fallible?: Boolean
 }
 
 /**


### PR DESCRIPTION
This change will allow clients to start transmitting information about the fallibility of jobs to the API server.

Importantly, this will allow Brigade's own worker component to send this info.